### PR TITLE
sub partitions

### DIFF
--- a/psqlextra/backend/migrations/operations/add_list_sub_partition.py
+++ b/psqlextra/backend/migrations/operations/add_list_sub_partition.py
@@ -1,0 +1,61 @@
+from psqlextra.backend.migrations.state import PostgresListPartitionState
+
+from .partition import PostgresPartitionOperation
+
+
+class PostgresAddListSubPartition(PostgresPartitionOperation):
+    """Adds a new list partition to a :see:PartitionedPostgresModel."""
+
+    def __init__(self, model_name, name, values, sub_key):
+        """Initializes new instance of :see:AddListPartition.
+
+        Arguments:
+            model_name:
+                The name of the :see:PartitionedPostgresModel.
+
+            name:
+                The name to give to the new partition table.
+
+            values:
+                Partition key values that should be
+                stored in this partition.
+        """
+
+        super().__init__(model_name, name)
+
+        self.values = values
+        self.sub_key = sub_key
+
+    def state_forwards(self, app_label, state):
+        model = state.models[(app_label, self.model_name_lower)]
+        model.add_partition(
+            PostgresListPartitionState(
+                app_label=app_label,
+                model_name=self.model_name,
+                name=self.name,
+                values=self.values,
+            )
+        )
+
+        state.reload_model(app_label, self.model_name_lower)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            schema_editor.add_list_sub_partition(model, self.name, self.values,self.sub_key)
+
+    def database_backwards(
+        self, app_label, schema_editor, from_state, to_state
+    ):
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            schema_editor.delete_partition(model, self.name)
+
+    def deconstruct(self):
+        name, args, kwargs = super().deconstruct()
+        kwargs["values"] = self.values
+
+        return name, args, kwargs
+
+    def describe(self) -> str:
+        return "Creates list partition %s on %s" % (self.name, self.model_name)

--- a/psqlextra/backend/migrations/operations/add_list_sub_partition.py
+++ b/psqlextra/backend/migrations/operations/add_list_sub_partition.py
@@ -42,7 +42,9 @@ class PostgresAddListSubPartition(PostgresPartitionOperation):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         model = to_state.apps.get_model(app_label, self.model_name)
         if self.allow_migrate_model(schema_editor.connection.alias, model):
-            schema_editor.add_list_sub_partition(model, self.name, self.values,self.sub_key)
+            schema_editor.add_list_sub_partition(
+                model, self.name, self.values, self.sub_key
+            )
 
     def database_backwards(
         self, app_label, schema_editor, from_state, to_state

--- a/psqlextra/backend/schema.py
+++ b/psqlextra/backend/schema.py
@@ -604,15 +604,22 @@ class PostgresSchemaEditor(SchemaEditor):
             self.quote_name(field_name) for field_name in meta.key
         )
 
+        if meta.primary_key:
+            primary_key_sql = ", ".join(
+                self.quote_name(field_name) for field_name in meta.primary_key
+            )
+        else:
+            primary_key_sql=partitioning_key_sql
+            
         # create a composite key that includes the partitioning key
         sql = sql.replace(" PRIMARY KEY", "")
         if model._meta.pk and model._meta.pk.name not in meta.key:
             sql = sql[:-1] + ", PRIMARY KEY (%s, %s))" % (
                 self.quote_name(model._meta.pk.name),
-                partitioning_key_sql,
+                primary_key_sql,
             )
         else:
-            sql = sql[:-1] + ", PRIMARY KEY (%s))" % (partitioning_key_sql,)
+            sql = sql[:-1] + ", PRIMARY KEY (%s))" % (primary_key_sql,)
 
         # extend the standard CREATE TABLE statement with
         # 'PARTITION BY ...'

--- a/psqlextra/backend/schema.py
+++ b/psqlextra/backend/schema.py
@@ -609,8 +609,8 @@ class PostgresSchemaEditor(SchemaEditor):
                 self.quote_name(field_name) for field_name in meta.sub_key
             )
         else:
-            primary_key_sql=partitioning_key_sql
-            
+            primary_key_sql = partitioning_key_sql
+
         # create a composite key that includes the partitioning key
         sql = sql.replace(" PRIMARY KEY", "")
         if model._meta.pk and model._meta.pk.name not in meta.key:

--- a/psqlextra/backend/schema.py
+++ b/psqlextra/backend/schema.py
@@ -78,9 +78,7 @@ class PostgresSchemaEditor(SchemaEditor):
     sql_add_list_partition = (
         "CREATE TABLE %s PARTITION OF %s FOR VALUES IN (%s)"
     )
-    sql_add_list_sub_partition = (
-        "CREATE TABLE %s PARTITION OF %s FOR VALUES IN (%s) PARTITION BY LIST (%s)"
-    )
+    sql_add_list_sub_partition = "CREATE TABLE %s PARTITION OF %s FOR VALUES IN (%s) PARTITION BY LIST (%s)"
     sql_delete_partition = "DROP TABLE %s"
     sql_table_comment = "COMMENT ON TABLE %s IS %s"
 
@@ -738,9 +736,10 @@ class PostgresSchemaEditor(SchemaEditor):
         name: str,
         values: List[Any],
         sub_key: str,
-        comment: Optional[str] = None
+        comment: Optional[str] = None,
     ) -> None:
-        """Creates a new list sub partition for the specified partitioned model.
+        """Creates a new list sub partition for the specified partitioned
+        model.
 
         Arguments:
             model:
@@ -762,13 +761,13 @@ class PostgresSchemaEditor(SchemaEditor):
         # asserts the model is a model set up for partitioning
         self._partitioning_properties_for_model(model)
 
-        #table_name = self.create_partition_table_name(model, name)
+        # table_name = self.create_partition_table_name(model, name)
 
         sql = self.sql_add_list_sub_partition % (
             self.quote_name(name),
             self.quote_name(model._meta.db_table),
             ",".join(["%s" for _ in range(len(values))]),
-            self.quote_name(sub_key)
+            self.quote_name(sub_key),
         )
 
         with transaction.atomic():
@@ -776,7 +775,6 @@ class PostgresSchemaEditor(SchemaEditor):
 
             if comment:
                 self.set_comment_on_table(name, comment)
-
 
     def add_hash_partition(
         self,

--- a/psqlextra/backend/schema.py
+++ b/psqlextra/backend/schema.py
@@ -604,9 +604,9 @@ class PostgresSchemaEditor(SchemaEditor):
             self.quote_name(field_name) for field_name in meta.key
         )
 
-        if meta.primary_key:
+        if meta.sub_key:
             primary_key_sql = ", ".join(
-                self.quote_name(field_name) for field_name in meta.primary_key
+                self.quote_name(field_name) for field_name in meta.sub_key
             )
         else:
             primary_key_sql=partitioning_key_sql

--- a/psqlextra/backend/schema.py
+++ b/psqlextra/backend/schema.py
@@ -761,8 +761,6 @@ class PostgresSchemaEditor(SchemaEditor):
         # asserts the model is a model set up for partitioning
         self._partitioning_properties_for_model(model)
 
-        # table_name = self.create_partition_table_name(model, name)
-
         sql = self.sql_add_list_sub_partition % (
             self.quote_name(name),
             self.quote_name(model._meta.db_table),

--- a/psqlextra/models/options.py
+++ b/psqlextra/models/options.py
@@ -12,13 +12,13 @@ class PostgresPartitionedModelOptions:
     are held.
     """
 
-    def __init__(self, method: PostgresPartitioningMethod, key: List[str], primary_key: List[str]):
+    def __init__(self, method: PostgresPartitioningMethod, key: List[str], sub_key: List[str]):
         self.method = method
         self.key = key
-        self.primary_key =  primary_key
+        self.sub_key =  sub_key
         self.original_attrs: Dict[
             str, Union[PostgresPartitioningMethod, List[str]]
-        ] = dict(method=method, key=key)
+        ] = dict(method=method, key=key,sub_key=sub_key)
 
 
 class PostgresViewOptions:

--- a/psqlextra/models/options.py
+++ b/psqlextra/models/options.py
@@ -1,5 +1,3 @@
-from re import sub
-from token import OP
 from typing import Dict, List, Optional, Union
 
 from psqlextra.types import PostgresPartitioningMethod, SQLWithParams
@@ -12,13 +10,18 @@ class PostgresPartitionedModelOptions:
     are held.
     """
 
-    def __init__(self, method: PostgresPartitioningMethod, key: List[str], sub_key: List[str]):
+    def __init__(
+        self,
+        method: PostgresPartitioningMethod,
+        key: List[str],
+        sub_key: List[str],
+    ):
         self.method = method
         self.key = key
-        self.sub_key =  sub_key
+        self.sub_key = sub_key
         self.original_attrs: Dict[
             str, Union[PostgresPartitioningMethod, List[str]]
-        ] = dict(method=method, key=key,sub_key=sub_key)
+        ] = dict(method=method, key=key, sub_key=sub_key)
 
 
 class PostgresViewOptions:

--- a/psqlextra/models/options.py
+++ b/psqlextra/models/options.py
@@ -1,3 +1,5 @@
+from re import sub
+from token import OP
 from typing import Dict, List, Optional, Union
 
 from psqlextra.types import PostgresPartitioningMethod, SQLWithParams
@@ -10,9 +12,10 @@ class PostgresPartitionedModelOptions:
     are held.
     """
 
-    def __init__(self, method: PostgresPartitioningMethod, key: List[str]):
+    def __init__(self, method: PostgresPartitioningMethod, key: List[str], primary_key: List[str]):
         self.method = method
         self.key = key
+        self.primary_key =  primary_key
         self.original_attrs: Dict[
             str, Union[PostgresPartitioningMethod, List[str]]
         ] = dict(method=method, key=key)

--- a/psqlextra/models/partitioned.py
+++ b/psqlextra/models/partitioned.py
@@ -25,9 +25,10 @@ class PostgresPartitionedModelMeta(ModelBase):
 
         method = getattr(meta_class, "method", None)
         key = getattr(meta_class, "key", None)
+        primary_key = getattr(meta_class, "primary_key", None)
 
         patitioning_meta = PostgresPartitionedModelOptions(
-            method=method or cls.default_method, key=key or cls.default_key
+            method=method or cls.default_method, key=key or cls.default_key , primary_key=primary_key or cls.default_key 
         )
 
         new_class.add_to_class("_partitioning_meta", patitioning_meta)

--- a/psqlextra/models/partitioned.py
+++ b/psqlextra/models/partitioned.py
@@ -27,13 +27,13 @@ class PostgresPartitionedModelMeta(ModelBase):
         key = getattr(meta_class, "key", None)
         sub_key = getattr(meta_class, "sub_key", None)
 
-        patitioning_meta = PostgresPartitionedModelOptions(
+        partitioning_meta = PostgresPartitionedModelOptions(
             method=method or cls.default_method,
             key=key or cls.default_key,
             sub_key=sub_key or cls.default_key,
         )
 
-        new_class.add_to_class("_partitioning_meta", patitioning_meta)
+        new_class.add_to_class("_partitioning_meta", partitioning_meta)
         return new_class
 
 

--- a/psqlextra/models/partitioned.py
+++ b/psqlextra/models/partitioned.py
@@ -28,7 +28,9 @@ class PostgresPartitionedModelMeta(ModelBase):
         sub_key = getattr(meta_class, "sub_key", None)
 
         patitioning_meta = PostgresPartitionedModelOptions(
-            method=method or cls.default_method, key=key or cls.default_key , sub_key=sub_key or cls.default_key 
+            method=method or cls.default_method,
+            key=key or cls.default_key,
+            sub_key=sub_key or cls.default_key,
         )
 
         new_class.add_to_class("_partitioning_meta", patitioning_meta)

--- a/psqlextra/models/partitioned.py
+++ b/psqlextra/models/partitioned.py
@@ -25,10 +25,10 @@ class PostgresPartitionedModelMeta(ModelBase):
 
         method = getattr(meta_class, "method", None)
         key = getattr(meta_class, "key", None)
-        primary_key = getattr(meta_class, "primary_key", None)
+        sub_key = getattr(meta_class, "sub_key", None)
 
         patitioning_meta = PostgresPartitionedModelOptions(
-            method=method or cls.default_method, key=key or cls.default_key , primary_key=primary_key or cls.default_key 
+            method=method or cls.default_method, key=key or cls.default_key , sub_key=sub_key or cls.default_key 
         )
 
         new_class.add_to_class("_partitioning_meta", patitioning_meta)

--- a/psqlextra/partitioning/plan.py
+++ b/psqlextra/partitioning/plan.py
@@ -54,7 +54,7 @@ class PostgresModelPartitioningPlan:
     def print(self) -> None:
         """Prints this model plan to the terminal in a readable format."""
 
-        print(f"{self.config.model.__name__}: ")
+        print(f"{self.config.model.__name__}:")
 
         for partition in self.deletions:
             print("  - %s" % partition.name())

--- a/psqlextra/partitioning/plan.py
+++ b/psqlextra/partitioning/plan.py
@@ -54,7 +54,7 @@ class PostgresModelPartitioningPlan:
     def print(self) -> None:
         """Prints this model plan to the terminal in a readable format."""
 
-        print(f"{self.config.model.__name__}:")
+        print(f"{self.config.model.__name__}: ")
 
         for partition in self.deletions:
             print("  - %s" % partition.name())

--- a/tests/test_make_migrations.py
+++ b/tests/test_make_migrations.py
@@ -30,19 +30,25 @@ from .migrations import apply_migration, make_migration
         dict(
             fields={"category": models.TextField()},
             partitioning_options=dict(
-                method=PostgresPartitioningMethod.LIST, key="category"
+                method=PostgresPartitioningMethod.LIST,
+                key="category",
+                sub_key=[],
             ),
         ),
         dict(
             fields={"timestamp": models.DateTimeField()},
             partitioning_options=dict(
-                method=PostgresPartitioningMethod.RANGE, key="timestamp"
+                method=PostgresPartitioningMethod.RANGE,
+                key="timestamp",
+                sub_key=[],
             ),
         ),
         dict(
             fields={"artist_id": models.IntegerField()},
             partitioning_options=dict(
-                method=PostgresPartitioningMethod.HASH, key="artist_id"
+                method=PostgresPartitioningMethod.HASH,
+                key="artist_id",
+                sub_key=[],
             ),
         ),
     ],

--- a/tests/test_management_command_partition.py
+++ b/tests/test_management_command_partition.py
@@ -101,6 +101,7 @@ def test_management_command_partition_dry_run(
     create/delete partitions."""
 
     config = fake_partitioning_manager.find_config_for_model(fake_model)
+
     snapshot.assert_match(run(args))
 
     config.strategy.createable_partition.create.assert_not_called()


### PR DESCRIPTION
The current implementation didn't offer sub partition support (customer_id, fund_family_id). This pr adds sub partition support for LIST partitions.

- Adding the ability to create sub partitions via migrations (PostgresAddListSubPartition)
- Updated the schema manager to correctly create the partitioned table with the appropriate unique constraint (id, customer_id, fund_family_id)
- fixed some tests